### PR TITLE
Fix creator page links to dynamic pages

### DIFF
--- a/assets/scripts/creator-list.js
+++ b/assets/scripts/creator-list.js
@@ -9,7 +9,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       const li = document.createElement('li');
       li.className = 'card';
       const a = document.createElement('a');
-      a.href = `/pages/creators/${c.slug}.html`;
+      a.href = `/creators/${c.slug}.html`;
       if (c.avatar_url) {
         const img = document.createElement('img');
         img.src = c.avatar_url;

--- a/functions/creators/my.js
+++ b/functions/creators/my.js
@@ -43,6 +43,6 @@ export async function onRequestGet({ request, env }) {
 
   return new Response(null, {
     status: 302,
-    headers: { Location: `/pages/creators/${page.slug}.html` },
+    headers: { Location: `/creators/${page.slug}.html` },
   });
 }


### PR DESCRIPTION
## Summary
- point the creator listing cards to the dynamic `/creators/{slug}.html` route so updates show up immediately
- update the my-page redirect to the same dynamic creator route

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cc7f34d75c833286d05f8e8e35d59b